### PR TITLE
fix: fetching download url (#1)

### DIFF
--- a/Install-Kubeseal.ps1
+++ b/Install-Kubeseal.ps1
@@ -2,8 +2,8 @@
 Write-Host "Creating the 'C:\bin\kubeseal' directory if it doesn't exist..."
 New-Item -ItemType Directory -Path "C:\bin\kubeseal" -ErrorAction Ignore
 
-# Get the releases from the GitHub API
-Write-Host "Retrieving the releases from the GitHub API..."
+# Get releases from the GitHub API
+Write-Host "Retrieving releases from the GitHub API..."
 $releasesResponse = Invoke-WebRequest -Uri https://api.github.com/repos/bitnami-labs/sealed-secrets/releases
 $releases = $releasesResponse.Content | ConvertFrom-Json
 

--- a/Install-Kubeseal.ps1
+++ b/Install-Kubeseal.ps1
@@ -2,13 +2,18 @@
 Write-Host "Creating the 'C:\bin\kubeseal' directory if it doesn't exist..."
 New-Item -ItemType Directory -Path "C:\bin\kubeseal" -ErrorAction Ignore
 
-# Get the latest release information from the GitHub API
-Write-Host "Retrieving the latest release information from the GitHub API..."
-$releaseInfo = Invoke-WebRequest -Uri https://api.github.com/repos/bitnami-labs/sealed-secrets/releases/latest
+# Get the releases from the GitHub API
+Write-Host "Retrieving the releases from the GitHub API..."
+$releasesResponse = Invoke-WebRequest -Uri https://api.github.com/repos/bitnami-labs/sealed-secrets/releases
+$releases = $releasesResponse.Content | ConvertFrom-Json
+
+# Get the release information for the latest release that has name starting with "shared-secrets-v"
+Write-Host "Getting the release information for the latest release that has name starting with 'shared-secrets-v'..."
+$releaseInfo = $releases | Where-Object { $_.name -match "^sealed-secrets-v" } | Select-Object -First 1
 
 # Extract the download URL for the Windows kubeseal binary
 Write-Host "Extracting the download URL for the Windows kubeseal binary..."
-$downloadUrl = ($releaseInfo | ConvertFrom-Json).assets | Where-Object { $_.name -match "^kubeseal-.*-windows-amd64\.tar\.gz$" } | Select-Object -ExpandProperty "browser_download_url"
+$downloadUrl = $releaseInfo.assets | Where-Object { $_.name -match "^kubeseal-.*-windows-amd64\.tar\.gz$" } | Select-Object -ExpandProperty "browser_download_url"
 
 # Download the kubeseal binary
 Write-Host "Downloading the kubeseal binary..."

--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 A simple PowerShell script that downloads the latest kubeseal CLI for Windows and adds it to the user's PATH.
 
 To use, run `Install-Kubeseal.ps1`.
+
+You might need to run `Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass` to allow the script to run.


### PR DESCRIPTION
Since bitnami-labs added the Helm-Chart into the repo the latest release could also be a Helm-Chart-Release. Those releases don't have the kubeseal-binary as an asset, thus failing the script. Those Helm-Chart-Releases are now filtered out.